### PR TITLE
PM 11706 fix nutrella gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2023-05-05
+
+#### Bug Fix
+
+- Fix board creation (which was broken due to changes in the Trello API)
+
 ## [1.7.0] - 2023-03-25
 
 - Update ruby-trello

--- a/lib/nutrella/task_board.rb
+++ b/lib/nutrella/task_board.rb
@@ -33,15 +33,7 @@ module Nutrella
     end
 
     def create(board_name)
-      create_board(board_name).tap { |board| make_team_visible(board) }
-    end
-
-    def create_board(board_name)
-      Trello::Board.create(name: board_name, organization_id: @organization)
-    end
-
-    def make_team_visible(board)
-      Trello.client.put("/boards/#{board.id}", "prefs/permissionLevel=org")
+      Trello::Board.create(name: board_name, organization_id: @organization, visibility_level: "org")
     end
   end
 end

--- a/lib/nutrella/version.rb
+++ b/lib/nutrella/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nutrella
-  VERSION = "1.7.0"
+  VERSION = "1.7.1"
 end

--- a/spec/integration/nutrella/nutrella_spec.rb
+++ b/spec/integration/nutrella/nutrella_spec.rb
@@ -29,11 +29,8 @@ RSpec.describe "Nutrella" do
       trello_search(board_name, search_result: [])
 
       allow(Trello::Board).to receive(:create)
-        .with(name: board_name, organization_id: "developer_organization")
+        .with(name: board_name, organization_id: "developer_organization", visibility_level: "org")
         .and_return(board)
-
-      expect_any_instance_of(Trello::Client).to receive(:put)
-        .with("/boards/#{board.id}", "prefs/permissionLevel=org")
 
       expect(command).to receive(:system).with("open #{url}")
 


### PR DESCRIPTION
- PM-11706: Update board creation to work with current Trello API
- PM-11706: Update changelog and bump version to 1.7.1
